### PR TITLE
Add redirect links

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -63,8 +63,8 @@ redir /get-help-in-rocketchat/ https://developer.gov.bc.ca/docs/default/componen
 redir /devops-security-compliance/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/security-and-privacy-compliance/devops-security-considerations/ permanent
 redir /security-best-practices-for-apps/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/security-and-privacy-compliance/security-best-practices-for-apps/ permanent
 redir /payment-card-processing/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/security-and-privacy-compliance/payment-card-processing/ permanent
-redir /vault-getting-started-guide/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/security-and-privacy-compliance/vault-getting-started-guide/ permanent
-redir /vault-secrets-management-service/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/security-and-privacy-compliance/vault-secrets-management-service/ permanent
+redir /vault-getting-started-guide/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/secrets-management/vault-getting-started-guide/ permanent
+redir /vault-secrets-management-service/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/secrets-management/vault-secrets-management-service/ permanent
 redir /training-from-the-platform-services-team/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/training-and-learning/training-from-the-platform-services-team/ permanent
 redir /training-external-resources/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/training-and-learning/training-external-resources/ permanent
 redir /bc-government-organizations-in-github/ https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/bc-government-organizations-in-github/ permanent
@@ -74,11 +74,15 @@ redir /evaluate-open-source-content/ https://developer.gov.bc.ca/docs/default/co
 redir /required-pages-for-github-repository/ https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/required-pages-for-github-repository/ permanent
 redir /start-working-in-bcgov-github-organization/ https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/start-working-in-bcgov-github-organization/ permanent
 redir /license-your-github-repository/ https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/license-your-github-repository/ permanent
-
-## New pages that need to be added to the mvp project
-# redir /project-examples/ 
-# redir /privacy-compliance-and-guidance/
-# redir /platform-security-tools/
+redir /hosting-tiers-table/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/platform-architecture-reference/hosting-tiers-table/ permanent
+redir /alertmanager/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/platform-automation/alertmanager/ permanent
+redir /automated-scaling/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/platform-automation/automated-scaling/ permanent
+redir /platform-automation/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/platform-automation/platform-automation/ permanent
+redir /project-examples/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/reusable-code-and-services/project-examples/ permanent
+redir /platform-security-tools/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/security-and-privacy-compliance/platform-security-tools/ permanent
+redir /devops-security-compliance/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/security-and-privacy-compliance/platform-security-compliance/ permanent
+redir /privacy-compliance-and-guidance/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/security-and-privacy-compliance/privacy-compliance-and-guidance/ permanent
+redir /argo-cd-shared-instances/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/automation-and-resiliency/argo-cd-usage/ permanent
 
 # On OCP we should log to stdout so Prometheus can
 # slurp up the logs for human consumption.


### PR DESCRIPTION
New pages were added with [private-cloud-techdocs PR59](https://github.com/bcgov/private-cloud-techdocs/pull/59). We need to redirect from the docs site to these pages.
