### PR TITLE
Update caddy dir permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ FROM caddy:2.10.0-alpine@sha256:e2e3a089760c453bc51c4e718342bd7032d6714f15b437db
 RUN caddy add-package github.com/caddyserver/transform-encoder   
 
 # From https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/images/creating-images#use-uid_create-images
-RUN mkdir -p /data/caddy /config/caddy && \
-    chgrp -R 0 /data /config && \
-    chmod -R g=u /data /config
+# Even though the admin and persistent config is turned off in the Caddyfile, caddy still creates files
+# in the data directory. So give it the appropriate permissions.
+RUN mkdir -p /data/caddy && \
+    chgrp -R 0 /data && \
+    chmod -R g=u /data
 
 WORKDIR /srv
 


### PR DESCRIPTION
Remove the `config directory` as it is not used. Only the `data` directory needs permission.
