### PR TITLE
DEVXT-2569: Provide unique error page

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -22,10 +22,6 @@
 		level info
 	}
 
-	handle_errors {
-		rewrite * /error.html
-		file_server
-	}
 }
 
 # Platform Developer Docs Redirects
@@ -106,6 +102,11 @@
 	redir /kyverno/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/platform-automation/kyverno/ permanent
 	redir /pruning/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/platform-automation/pruning/ permanent
 	redir /devops-security-considerations/ https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/ permanent
+
+	handle_errors {
+		rewrite * /error.html
+		file_server
+	}
 }
 
 # SO Redirects
@@ -1738,6 +1739,10 @@
 	redir /questions/1117/1118 https://github.com/bcgov/bcgov-community-discussions/discussions/360#discussioncomment-14949943 permanent
 	redir /a/1118 https://github.com/bcgov/bcgov-community-discussions/discussions/360#discussioncomment-14949943 permanent
 
+	handle_errors {
+		rewrite * /error_so.html
+		file_server
+	}
 }
 
 # Health check endpoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 
-COPY error.html /srv/error.html
+COPY error.html error_so.html /srv/
 
 EXPOSE 2015 2016 2017
 

--- a/error_so.html
+++ b/error_so.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Error</title>
+    <meta name="description" content="Error">
+  </head>
+  <body>
+    <h1>Site has moved</h1>
+    <p>The BC Gov Stackoverflow has been migrated to <a href="https://github.com/bcgov/bcgov-community-discussions/discussions">GitHub Discussions</a>. Please search for your Q&amp;A there.</p>
+  </body>
+</html>


### PR DESCRIPTION
The Caddyfile originally used one error.html file. This meant the same error message was displayed regardless of whether the error happened for ports 2015 or 2017. Because the error file was docs.developer.gov.bc.ca specific it is not applicable to the SO rewrites.

This PR defines error.html files for each redirect block.
